### PR TITLE
Change to use audio codec == 'copy'

### DIFF
--- a/src/ffmpeg_smart_trim/trim.py
+++ b/src/ffmpeg_smart_trim/trim.py
@@ -11,7 +11,6 @@ class TrimVideo:
     def __init__(self, video_path, temp_dir=None, time_range: (Decimal, Decimal) = None):
         probe = ffmpeg.probe(video_path, skip_frame="nokey", show_entries="frame=pkt_pts_time", select_streams="v:0")
         self.vcodec = ffmpeg.probe(video_path, select_streams="v:0")['streams'][0]['codec_name']
-        self.acodec = ffmpeg.probe(video_path, select_streams="a:0")['streams'][0]['codec_name']
         self.key_frame_timestamps = [Decimal(frame['pkt_pts_time']) for frame in probe['frames']]
         self.duration = Decimal(probe['streams'][0]['duration'])
         self.video_path = video_path
@@ -64,7 +63,7 @@ class TrimVideo:
                 new_input = ffmpeg.input(self.video_path, ss=start, to=end)
                 return ffmpeg.output(new_input, path, c='copy')
             else:
-                return ffmpeg.output(self.input_file, path, acodec=self.acodec, vcodec=self.vcodec, ss=start, to=end)
+                return ffmpeg.output(self.input_file, path, acodec='copy', vcodec=self.vcodec, ss=start, to=end)
 
         if start_key_frame > end_key_frame:  # start_time and end_time with in same key_frame
             output = os.path.join(self.temp_dir, f"{prefix}_output.ts")


### PR DESCRIPTION
It's unnecessary to encode the audio if the codec is not being changed.

So, now it uses acodec='copy'