### PR TITLE
add check for format duration

### DIFF
--- a/src/ffmpeg_smart_trim/trim.py
+++ b/src/ffmpeg_smart_trim/trim.py
@@ -12,7 +12,10 @@ class TrimVideo:
         probe = ffmpeg.probe(video_path, skip_frame="nokey", show_entries="frame=pts_time", select_streams="v:0")
         self.vcodec = ffmpeg.probe(video_path, select_streams="v:0")['streams'][0]['codec_name']
         self.key_frame_timestamps = [Decimal(frame['pts_time']) for frame in probe['frames']]
-        self.duration = Decimal(probe['streams'][0]['duration'])
+        try:
+            self.duration = Decimal(probe['streams'][0]['duration'])
+        except KeyError:
+            self.duration = Decimal(probe['format']['duration'])
         self.video_path = video_path
         if time_range is None:
             self.input_file: ffmpeg.nodes.FilterableStream = ffmpeg.input(video_path)


### PR DESCRIPTION
mkv files (and possibly others) lack an entry for the video stream duration
This adds the ability to use the format duration in its place.